### PR TITLE
Fixes Sicos1977/QPdfNet#8

### DIFF
--- a/QPdfNet/Job.cs
+++ b/QPdfNet/Job.cs
@@ -51,7 +51,7 @@ namespace QPdfNet;
 public class Job : IDisposable
 {
     #region Delegates
-    private delegate void Callback(IntPtr data, int length);
+    private delegate int Callback(IntPtr data, int length);
     #endregion
 
     #region Fields
@@ -206,32 +206,36 @@ public class Job : IDisposable
     #endregion
 
     #region Callbacks
-    private void InfoCallback(IntPtr data, int length)
+    private int InfoCallback(IntPtr data, int length)
     {
         var bytes = new byte[length];
         Marshal.Copy(data, bytes, 0, length);
         _info!.Append(Encoding.ASCII.GetString(bytes));
+        return 0;
     }
 
-    private void WarnCallback(IntPtr data, int length)
+    private int WarnCallback(IntPtr data, int length)
     {
         var bytes = new byte[length];
         Marshal.Copy(data, bytes, 0, length);
         _warn!.Append(Encoding.ASCII.GetString(bytes));
+        return 0;
     }
 
-    private void ErrorCallback(IntPtr data, int length)
+    private int ErrorCallback(IntPtr data, int length)
     {
         var bytes = new byte[length];
         Marshal.Copy(data, bytes, 0, length);
         _error!.Append(Encoding.ASCII.GetString(bytes));
+        return 0;
     }
 
-    private void SaveCallback(IntPtr data, int length)
+    private int SaveCallback(IntPtr data, int length)
     {
         var bytes = new byte[length];
         Marshal.Copy(data, bytes, 0, length);
         _save!.AddRange(bytes.Select(b => b));
+        return 0;
     }
     #endregion
 


### PR DESCRIPTION
**Short explanation**
The signatures of the callback methods in the C# wrapper did not match the signatures of the corresponding functions in the QPDF C++ library. It worked in .NET 6.0+ because in those versions, the case of "mismatched signatures" is not treated as critically as in .NET 4.8.1-. It is my guess. There might be information about this in the release notes, but I didn't find anything.

**Long explanation**
The native C++ functions that are loaded:

1. `void qpdflogger_set_info(qpdflogger_handle l, enum qpdf_log_dest_e dest, qpdf_log_fn_t fn, void*udata);` ([line 69](https://github.com/qpdf/qpdf/blob/b1b789df4203296a848fec6a3513f30efceb1a45/include/qpdf/qpdflogger-c.h#L69))
2. `void qpdflogger_set_warn( qpdflogger_handle l, enum qpdf_log_dest_e dest, qpdf_log_fn_t fn, void* udata);` ([line 72](https://github.com/qpdf/qpdf/blob/b1b789df4203296a848fec6a3513f30efceb1a45/include/qpdf/qpdflogger-c.h#L72))
3. `void qpdflogger_set_error( qpdflogger_handle l, enum qpdf_log_dest_e dest, qpdf_log_fn_t fn, void* udata);` ([line 75](https://github.com/qpdf/qpdf/blob/b1b789df4203296a848fec6a3513f30efceb1a45/include/qpdf/qpdflogger-c.h#L75))
4. `void qpdflogger_set_save( qpdflogger_handle l, enum qpdf_log_dest_e dest, qpdf_log_fn_t fn, void* udata, int only_if_not_set);` ([line 82](https://github.com/qpdf/qpdf/blob/b1b789df4203296a848fec6a3513f30efceb1a45/include/qpdf/qpdflogger-c.h#L82))

They all use callbacks of type `int (*qpdf_log_fn_t)(char const* data, size_t len, void* udata);` ([line 66](https://github.com/qpdf/qpdf/blob/b1b789df4203296a848fec6a3513f30efceb1a45/include/qpdf/qpdflogger-c.h#L66))
Note: Return type is int. Also, refer to the comment at line [65](https://github.com/qpdf/qpdf/blob/b1b789df4203296a848fec6a3513f30efceb1a45/include/qpdf/qpdflogger-c.h#L65): `Function should return 0 on success`.

The callbacks used in the C# wrapper have a different signature. Taking `InfoCallback` as an example (the others follow a similar pattern):
```cs
private void InfoCallback(IntPtr data, int length)
    {
        var bytes = new byte[length];
        Marshal.Copy(data, bytes, 0, length);
        _info!.Append(Encoding.ASCII.GetString(bytes));
    }
```
Note: Return type is `void`; the method does not return anything.

**Fix**
1. Change the return type of the delegate (`void` -> `int`).
2. Modify the return type of the callback methods (`void` -> `int`), return `0` in the callbacks.

With this fix, your library works for me with both .NET Framework 4.8 and .NET 8.0.