### PR TITLE
Fix logic error in creation of log message

### DIFF
--- a/QPdfNet/Job.cs
+++ b/QPdfNet/Job.cs
@@ -390,8 +390,8 @@ public class Job : IDisposable
     public Job ReplaceInput()
     {
         Logger.LogInformation(string.IsNullOrEmpty(_inputFile)
-            ? $"Replacing input PDF file '{_inputFile}'"
-            : "Replacing input PDF file");
+            ? "Replacing input PDF file"
+            : $"Replacing input PDF file '{_inputFile}'");
 
         _replaceInput = string.Empty;
         return this;


### PR DESCRIPTION
A logic error caused the variants  of logging message in `Job.ReplaceInput()` to be swapped, compared to the obviously intended way:

If `_inputFile` == "" (or null):
bug:   `Replacing input PDF file ''`
fix:  `Replacing input PDF file`

If `_inputFile` == "foo.pdf":
bug:   `Replacing input PDF file`
fix:  `Replacing input PDF file 'foo.pdf'`

**Remark:** Instead of switching branches from `X ? Y : Z` to `X ? Z : Y` in the ternary operator, one might simply negate the condition to `!X ? Y : Z`
However, I strongly prefer to not negate conditions when the branches have comparable complexity